### PR TITLE
Update regex for support unicode chars

### DIFF
--- a/lib/redis-search.js
+++ b/lib/redis-search.js
@@ -182,7 +182,7 @@ function addIndexCommands(cmds, namespace, index, indexValue, id) {
 }
 
 function toWords(content) {
-  return String(content).match(/\w+/g);
+  return String(content).match(/\p{Letter}/ug);
 }
 
 function metaphoneKeys(key, index, words) {

--- a/lib/redis-search.js
+++ b/lib/redis-search.js
@@ -182,7 +182,7 @@ function addIndexCommands(cmds, namespace, index, indexValue, id) {
 }
 
 function toWords(content) {
-  return String(content).match(/\p{Letter}/ug);
+  return String(content).match(/[\p{L}_]+/ug);
 }
 
 function metaphoneKeys(key, index, words) {


### PR DESCRIPTION
The regular abbreviation `\w` is equivalent to `[a-zA-Z0-9_]`, and does not include Hebrew characters for example - https://regex101.com/r/CkI7AL/1
This PR moves to use ES2018's [Unicode Property Escapes,](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) to fully support Unicode characters.
See more here: https://stackoverflow.com/a/48902765/17059718